### PR TITLE
DSR-1337: fixed uninit bytes issue

### DIFF
--- a/ports/linux/rs485.c
+++ b/ports/linux/rs485.c
@@ -461,7 +461,7 @@ void RS485_Send_Frame(
 void RS485_Check_UART_Data(volatile struct mstp_port_struct_t *mstp_port)
 {
     fd_set input;
-    struct timeval waiter;
+    struct timeval waiter = {};
     uint8_t buf[2048];
     int n;
 


### PR DESCRIPTION
During stress testing for this PR:
https://github.com/IOTechSystems/device-bacnet-c-private/pull/74

An issue was highlighted by valgrind:

==81995== Thread 14:
==81995== Syscall param select(timeout) points to uninitialised byte(s)
==81995==    at 0x4CAC12B: select (select.c:41)
==81995==    by 0x48C7F94: RS485_Check_UART_Data (in /home/fraser/ClionProjects/XRT_projects/bacnet/mutex/device-bacnet-c-private/lib/mstp/libbacnet-stack.so)
==81995==    by 0x48C8F2F: dlmstp_master_fsm_task (in /home/fraser/ClionProjects/XRT_projects/bacnet/mutex/device-bacnet-c-private/lib/mstp/libbacnet-stack.so)
==81995==    by 0x49BD608: start_thread (pthread_create.c:477)
==81995==    by 0x4CB6292: clone (clone.S:95)
==81995==  Address 0xcb163a0 is on thread 14's stack
==81995==  in frame #1, created by RS485_Check_UART_Data (???:)
==81995==

This small change fixes the issue.