### PR TITLE
DSR 1471: Race condition and valgrind hanging fixes

### DIFF
--- a/src/bacnet/basic/bbmd/h_bbmd.c
+++ b/src/bacnet/basic/bbmd/h_bbmd.c
@@ -1179,11 +1179,7 @@ int bvlc_register_with_bbmd(BACNET_IP_ADDRESS *bbmd_addr, uint16_t ttl_seconds)
         timeout.tv_nsec = 0;
         pthread_mutex_lock (&mutex);
         pthread_cond_timedwait (&cond, &mutex, &timeout);
-        if (bbmd_reg_success)
-        {
-            pthread_mutex_unlock (&mutex);
-            break;
-        }
+        if (bbmd_reg_success) timeout_count = 10;
         pthread_mutex_unlock (&mutex);
         timeout_count++;
     }

--- a/src/bacnet/basic/bbmd/h_bbmd.c
+++ b/src/bacnet/basic/bbmd/h_bbmd.c
@@ -1153,14 +1153,11 @@ int bvlc_register_with_bbmd(BACNET_IP_ADDRESS *bbmd_addr, uint16_t ttl_seconds)
     BVLC_Buffer_Len = bvlc_encode_register_foreign_device(
         &BVLC_Buffer[0], sizeof(BVLC_Buffer), ttl_seconds);
 
-    pthread_mutex_init (&mutex, NULL);
-
     /* Set the initial value of the BBMD registration bool to false */
-    pthread_mutex_lock (&mutex);
     bbmd_reg_success = false;
-    pthread_mutex_unlock (&mutex);
 
     /* Setup a 30 second condition variable wait */
+    pthread_mutex_init (&mutex, NULL);
     pthread_cond_init (&cond, NULL);
     time_t timeout_seconds = 30;
     struct timeval now;

--- a/src/bacnet/basic/bbmd/h_bbmd.c
+++ b/src/bacnet/basic/bbmd/h_bbmd.c
@@ -1166,9 +1166,6 @@ int bvlc_register_with_bbmd(BACNET_IP_ADDRESS *bbmd_addr, uint16_t ttl_seconds)
     struct timeval now;
     struct timespec timeout;
     int timeout_count = 0;
-    gettimeofday (&now, NULL);
-    timeout.tv_sec = now.tv_sec + timeout_seconds;
-    timeout.tv_nsec = 0;
 
     int retval = bip_send_mpdu(bbmd_addr, &BVLC_Buffer[0], BVLC_Buffer_Len);
     if (retval == -1)

--- a/src/bacnet/basic/bbmd/h_bbmd.c
+++ b/src/bacnet/basic/bbmd/h_bbmd.c
@@ -1162,7 +1162,7 @@ int bvlc_register_with_bbmd(BACNET_IP_ADDRESS *bbmd_addr, uint16_t ttl_seconds)
 
     /* Setup a 30 second condition variable wait */
     pthread_cond_init (&cond, NULL);
-    time_t timeout_seconds = 5;
+    time_t timeout_seconds = 3;
     struct timeval now;
     struct timespec timeout;
     int timeout_count = 0;
@@ -1172,7 +1172,7 @@ int bvlc_register_with_bbmd(BACNET_IP_ADDRESS *bbmd_addr, uint16_t ttl_seconds)
     {
         return retval;
     }
-    while (timeout_count < 6)
+    while (timeout_count < 10)
     {
         gettimeofday (&now, NULL);
         timeout.tv_sec = now.tv_sec + timeout_seconds;

--- a/src/bacnet/basic/bbmd/h_bbmd.c
+++ b/src/bacnet/basic/bbmd/h_bbmd.c
@@ -842,14 +842,12 @@ int bvlc_bbmd_enabled_handler(BACNET_IP_ADDRESS *addr,
             }
             /* Set the BBMD registration bool to successful, signal the condition variable and unlock the mutex */
             pthread_mutex_lock (&mutex);
-
             if (bbmd_reg_success == false)
             {
                 bbmd_reg_success = true;
                 pthread_cond_signal (&cond);
             }
             pthread_mutex_unlock (&mutex);
-
             break;
         case BVLC_WRITE_BROADCAST_DISTRIBUTION_TABLE:
             debug_print_bip("Received Write-BDT", addr);

--- a/src/bacnet/basic/bbmd/h_bbmd.c
+++ b/src/bacnet/basic/bbmd/h_bbmd.c
@@ -1153,11 +1153,14 @@ int bvlc_register_with_bbmd(BACNET_IP_ADDRESS *bbmd_addr, uint16_t ttl_seconds)
     BVLC_Buffer_Len = bvlc_encode_register_foreign_device(
         &BVLC_Buffer[0], sizeof(BVLC_Buffer), ttl_seconds);
 
+    pthread_mutex_init (&mutex, NULL);
+    
+    pthread_mutex_lock (&mutex);
     /* Set the initial value of the BBMD registration bool to false */
     bbmd_reg_success = false;
+    pthread_mutex_unlock (&mutex);
 
     /* Setup a 30 second condition variable wait */
-    pthread_mutex_init (&mutex, NULL);
     pthread_cond_init (&cond, NULL);
     time_t timeout_seconds = 30;
     struct timeval now;

--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -521,9 +521,6 @@ int dlenv_init(void)
     }
 #endif
     dlenv_network_port_init();
-    if (dlenv_register_as_foreign_device() < 0)
-    {
-        return 1;
-    }
+
     return 0;
 }


### PR DESCRIPTION
The changes in the stack include:
 
- Adding a missing mutex lock on the ack handler of BBMD, 
- Allowing for the BBMD wait condition to wait more than once
  - Found that under valgrind, the message response would trigger the condition before it had even reached the wait meaning you would have to wait for the timeout of 30 seconds to finish init 
- Removing the BBMD set up from dlenv_init, where it will now be called from the DS where the reason for this was to avoid a data race on BIP_Socket. This was because the BBMD set up required the thread running, but with the thread running, it uses BIP_Socket where a race condition then occurs when dlenv_init() is called, but with the BBMD set up removed from the dlenv_init() function,  dlenv_init() can then be called first, then the thread and then the BBMD set up