### PR TITLE
XRT-1083: Small extra updates to sim behaviour and updated device object name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - These files will still be included in a build of the simulator as that build process uses the Makefile
 - Disable BACnet routing as is currently not used in the device service
     - Because of this, we can now set our device ID as something other than 0
+- Updated Device Service object name
 
 ### Related to Simulator
 
@@ -16,3 +17,6 @@
 - Updated identifying values of device object
 - Updated handling logic of script and populate arguments
 - Updated default behaviour when no arguments provided where device instance is 1234 and it populates the sim with 1 of each object
+- Updated how the priority arrays are initialised for Binary Analog Output, Binary Output and Binary Value
+- Removed any rules on setting certain priority levels
+- Updated device object name for simulator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,6 @@
 - Updated identifying values of device object
 - Updated handling logic of script and populate arguments
 - Updated default behaviour when no arguments provided where device instance is 1234 and it populates the sim with 1 of each object
-- Updated how the priority arrays are initialised for Binary Analog Output, Binary Output and Binary Value
+- Updated how the priority arrays are initialised for Analog Output, Binary Output and Binary Value
 - Removed any rules on setting certain priority levels
 - Updated device object name for simulator

--- a/src/bacnet/basic/object/ao.c
+++ b/src/bacnet/basic/object/ao.c
@@ -93,7 +93,11 @@ void Analog_Output_Set_Properties(
 )
 {
     Analog_Output_Name_Set(object_instance, object_name);
-    Analog_Output_Present_Value_Set(object_instance, value, 1);
+    Analog_Output_Present_Value_Set(object_instance, value, 16);
+    for (uint8_t i = 1; i < BACNET_MAX_PRIORITY; i++)
+    {
+        Analog_Output_Present_Value_Set(object_instance, AO_LEVEL_NULL, i);
+    }
 }
 
 void Analog_Output_Add(size_t count)
@@ -264,9 +268,7 @@ bool Analog_Output_Present_Value_Set(
 
     index = Analog_Output_Instance_To_Index(object_instance);
     if (index < AO_Descr_Size) {
-        if (priority && (priority <= BACNET_MAX_PRIORITY) &&
-            (priority != 6 /* reserved */) && (value >= 0.0) &&
-            (value <= 100.0)) {
+        if (priority && (priority <= BACNET_MAX_PRIORITY)) {
             pthread_mutex_lock(&AO_Descr_Mutex);
             AO_Descr[index].Level[priority - 1] = value;
             pthread_mutex_unlock(&AO_Descr_Mutex);

--- a/src/bacnet/basic/object/bo.c
+++ b/src/bacnet/basic/object/bo.c
@@ -92,7 +92,11 @@ void Binary_Output_Set_Properties(
     }   
 
     Binary_Output_Name_Set(object_instance, object_name);
-    Binary_Output_Present_Value_Set(object_instance, value,1);
+    Binary_Output_Present_Value_Set(object_instance, value,16);
+    for (uint8_t i = 1; i < BACNET_MAX_PRIORITY; i++)
+    {
+        Binary_Output_Present_Value_Set(object_instance, BINARY_NULL, i);
+    }
     
     pthread_mutex_lock(&BO_Descr_Mutex);
     BO_Descr[index].Out_Of_Service = out_of_service;

--- a/src/bacnet/basic/object/bo.c
+++ b/src/bacnet/basic/object/bo.c
@@ -261,8 +261,7 @@ bool Binary_Output_Present_Value_Set(
 
     index = Binary_Output_Instance_To_Index(object_instance);
     if (index < BO_Descr_Size) {
-        if (priority && (priority <= BACNET_MAX_PRIORITY) &&
-            (priority != 6 /* reserved */)) {
+        if (priority && (priority <= BACNET_MAX_PRIORITY)) {
             pthread_mutex_lock(&BO_Descr_Mutex);
             BO_Descr[index].Level[priority - 1] = binary_value;
             pthread_mutex_unlock(&BO_Descr_Mutex);

--- a/src/bacnet/basic/object/bv.c
+++ b/src/bacnet/basic/object/bv.c
@@ -99,7 +99,11 @@ void Binary_Value_Set_Properties(
     }   
 
     Binary_Value_Name_Set(object_instance, object_name);
-    Binary_Value_Present_Value_Set(object_instance, value, 1);
+    Binary_Value_Present_Value_Set(object_instance, value, 16);
+    for (uint8_t i = 1; i < BACNET_MAX_PRIORITY; i++)
+    {
+        Binary_Value_Present_Value_Set(object_instance, BINARY_NULL, i);
+    }
     Binary_Value_Out_Of_Service_Set(object_instance, out_of_service);
 }
 

--- a/src/bacnet/basic/object/bv.c
+++ b/src/bacnet/basic/object/bv.c
@@ -131,15 +131,8 @@ void Binary_Value_Add(size_t count)
         pthread_mutex_lock(&BV_Descr_Mutex);
         BV_Descr[i].Name = NULL;
         pthread_mutex_unlock(&BV_Descr_Mutex);
-
-
         snprintf(name_buffer, 64, "binary_value_%zu", i);
-        Binary_Value_Set_Properties(
-            i, 
-            name_buffer,
-            BINARY_ACTIVE,
-            false
-        );
+        Binary_Value_Set_Properties(i, name_buffer, BINARY_ACTIVE, false);
     }
 }
 
@@ -295,12 +288,10 @@ bool Binary_Value_Present_Value_Set(
 
     index = Binary_Value_Instance_To_Index(object_instance);
     if (index < BV_Descr_Size) {
-        if (priority && (priority <= BACNET_MAX_PRIORITY) &&
-            (priority != 6 /* reserved */)) {
+        if (priority && (priority <= BACNET_MAX_PRIORITY)) {
             pthread_mutex_lock(&BV_Descr_Mutex);
             BV_Descr[index].Level[priority -1] = binary_value;
             pthread_mutex_unlock(&BV_Descr_Mutex);
-            
             status = true;
         }
     }

--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -1845,7 +1845,7 @@ void Device_Init(object_functions_t *object_table)
 #ifdef BACNET_SIMULATOR
         characterstring_init_ansi(&My_Object_Name, "IOTech BACnet Simulator");
 #else
-        characterstring_init_ansi(&My_Object_Name, "IOTech Edge XRT BACnet");
+        characterstring_init_ansi(&My_Object_Name, "IOTech Edge XRT BACnet Device Service Component");
 #endif
 #if defined(BAC_UCI)
     }

--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -1842,7 +1842,11 @@ void Device_Init(object_functions_t *object_table)
         characterstring_init_ansi(&My_Object_Name, uciname);
     } else {
 #endif /* defined(BAC_UCI) */
-        characterstring_init_ansi(&My_Object_Name, "SimpleServer");
+#ifdef BACNET_SIMULATOR
+        characterstring_init_ansi(&My_Object_Name, "IOTech BACnet Simulator");
+#else
+        characterstring_init_ansi(&My_Object_Name, "IOTech Edge XRT BACnet");
+#endif
 #if defined(BAC_UCI)
     }
     ucix_cleanup(ctx);


### PR DESCRIPTION
### Related to Simulator

- Updated how the priority arrays are initialised for Analog Output, Binary Output and Binary Value objects, where the lowest priority is set and the rest are set to null
- Removed any rules on setting certain priority levels
- Updated device object name for simulator from "SimpleServer" to "IOTech BACnet Simulator"

### Related to Device Service

- Updated Device Service object name from "SimpleServer" to "IOTech Edge XRT BACnet Device Service Component"
