### PR TITLE
XRT-1155: updated cmakelist to remove unrequired routing files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,8 @@ add_library(${PROJECT_NAME}
     src/bacnet/basic/binding/address.h
     src/bacnet/basic/npdu/h_npdu.c
     src/bacnet/basic/npdu/h_npdu.h
-    src/bacnet/basic/npdu/h_routed_npdu.c
-    src/bacnet/basic/npdu/h_routed_npdu.h
+    $<$<BOOL:${BAC_ROUTING}>:src/bacnet/basic/npdu/h_routed_npdu.c>
+    $<$<BOOL:${BAC_ROUTING}>:src/bacnet/basic/npdu/h_routed_npdu.h>
     src/bacnet/basic/npdu/s_router.c
     src/bacnet/basic/npdu/s_router.h
     $<$<BOOL:${BACNET_SIMULATOR}>:src/bacnet/basic/object/access_credential.c>


### PR DESCRIPTION
There is currently two symbols that are undefined in the bacnet library

                U Routed_Device_GetNext
                U Routed_Device_Is_Valid_Network

This has caused issues running the alpine version of bacnet, giving:
`Routed_Device_GetNext: symbol not found
`

These functions are not directly or indirectly called by the device service, they are just used in stack functions that are never called by the device service as routing is now disabled. On Ubuntu the library can run with no problems but alpine seems to have an issue with them. The fix just removes these files that call these functions as they are never used anyway.

A dev build of libbacnet has already been built and used by XRT where you can now see the bacnet example running:
https://jenkins.iotechsys.com/job/XRT/job/XRT-940-branch/11/execution/node/28/log/

Once merged will re-tag the stack as v1.0.2 as re-build on all platforms

In review for @SteveOss 