### PR TITLE
JCI-159 bind to single interface if specified

### DIFF
--- a/ports/linux/bip-init.c
+++ b/ports/linux/bip-init.c
@@ -872,7 +872,7 @@ bool bip_init(char *ifname)
     if (status < 0) {
         close(sock_fd);
         BIP_Socket = -1;
-        return status;
+        return false;
     }
     /* allow us to send a broadcast */
     status = setsockopt(
@@ -884,7 +884,7 @@ bool bip_init(char *ifname)
     }
     /* bind the socket to the local port number and IP address */
     sin.sin_family = AF_INET;
-    sin.sin_addr.s_addr = htonl(INADDR_ANY);
+    sin.sin_addr.s_addr = ifname ? BIP_Address.s_addr : htonl(INADDR_ANY);
     sin.sin_port = BIP_Port;
     memset(&(sin.sin_zero), '\0', sizeof(sin.sin_zero));
     status =


### PR DESCRIPTION
This patch changes the behavior of the stack such that if a network interface is specified, it will bind to the address of that interface for sending and listening. If the interface is not specified, the previous behavior of binding to any/all ("0.0.0.0") is retained.

It also fixes a potential issue where initialization would wrongly succeed if `SO_REUSEADDR` was not available for some reason.
